### PR TITLE
Add `lang` attribute to `html` start tag

### DIFF
--- a/tapestry.html
+++ b/tapestry.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html lang=en>
 <html>
   <head>
     <title>Tapestry</title>


### PR DESCRIPTION
Declare the language of this document to fix W3C's linter warning.
Value has been set to `en` (valid BCP 47 language tag).
[documentation](https://www.w3.org/TR/html52/dom.html#the-lang-and-xmllang-attributes)